### PR TITLE
Added missing $filename reference if $wkhtml_filename is given.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class wkhtmltox (
   include wget
 
   if $wkhtml_filename {
+    $filename          = $wkhtml_filename
     $download_location = "${download_url}/${wkhtml_filename}"
   }
   else {


### PR DESCRIPTION
See #1. This PR fixes:

``` bash
==> default: Error: Execution of '/usr/bin/dpkg --force-confold -i /tmp/' returned 1: dpkg-split: error: error reading /tmp/: Is a directory
==> default: dpkg: error processing archive /tmp/ (--install):
==> default:  subprocess dpkg-split returned error exit status 2
==> default: Errors were encountered while processing:
==> default:  /tmp/
==> default: 
==> default: Error: /Stage[main]/Wkhtmltox/Package[wkhtmltox]/ensure: change from purged to present failed: Execution of '/usr/bin/dpkg --force-confold -i /tmp/' returned 1: dpkg-split: error: error reading /tmp/: Is a directory
==> default: dpkg: error processing archive /tmp/ (--install):
==> default:  subprocess dpkg-split returned error exit status 2
==> default: Errors were encountered while processing:
==> default:  /tmp/
==> default: 
```

on:

``` puppet
class {'::wkhtmltox':
    ensure          => present,
    use_downloader  => true,
    download_url    => 'http://0.0.0.0:8080/packages/wkhtmltopdf',
    wkhtml_filename => 'wkhtmltox-0.12.1_linux-trusty-amd64.deb'
}
```
