### PR TITLE
Updating download_url since gna.org seems no longer to be available.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class wkhtmltox (
   $packagetype     = $::wkhtmltox::params::packagetype,
   $provider        = $::wkhtmltox::params::provider,
   $required_pkgs   = $::wkhtmltox::params::required_pkgs,
-  $download_url    = 'http://download.gna.org/wkhtmltopdf',
+  $download_url    = 'https://downloads.wkhtmltopdf.org',
   $wkhtml_filename = undef,
   $use_downloader  = true,
 ) inherits ::wkhtmltox::params {


### PR DESCRIPTION
The specified download_url (http://download.gna.org) no longer seems to be available. We tried wkhtmltopdf.org which seems to work.